### PR TITLE
Remove duplicate import in gamification system

### DIFF
--- a/mall_gamification_system.py
+++ b/mall_gamification_system.py
@@ -24,7 +24,6 @@
 import time
 import random
 import re
-import time
 from datetime import datetime, timedelta
 from collections import defaultdict
 import json


### PR DESCRIPTION
## Summary
- remove redundant `import time` in mall_gamification_system

## Testing
- `black --check mall_gamification_system.py` *(fails: would reformat)*
- `flake8 mall_gamification_system.py` *(fails: command not found)*
- `pytest` *(fails: SyntaxError in test_ui_system.py)*

------
https://chatgpt.com/codex/tasks/task_e_689221d98ed0832eaf6dcf4cf9358233