### PR TITLE
Use environment variable for Flask secret key

### DIFF
--- a/CONFIGURATION_SETUP_SUMMARY.md
+++ b/CONFIGURATION_SETUP_SUMMARY.md
@@ -112,7 +112,7 @@
 
 ### Environment Variables:
 - **JWT_SECRET_KEY** - JWT token signing
-- **SECRET_KEY** - Flask session security
+- **FLASK_SECRET_KEY** - Flask session security
 - **DATABASE_URL** - Database connection
 - **REDIS_URL** - Cache connection
 - **MFA_ENABLED** - Multi-factor authentication
@@ -265,7 +265,7 @@ docker-compose --profile staging up -d
 
 ### ✅ Required Setup:
 - [ ] Copy `env.example` to `.env`
-- [ ] Set secure `SECRET_KEY` and `JWT_SECRET_KEY`
+- [ ] Set secure `FLASK_SECRET_KEY` and `JWT_SECRET_KEY`
 - [ ] Configure `DATABASE_URL` for your environment
 - [ ] Set `REDIS_URL` if using Redis
 - [ ] Configure `FLASK_ENV` (development/production/testing)

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@
    pip install -r requirements.txt
    ```
 
-3. **إعداد متغيرات البيئة (اختياري)**
+3. **إعداد متغيرات البيئة**
    ```bash
    cp env.example .env
+   export FLASK_SECRET_KEY=your-secret-key
    # تحرير ملف .env حسب الحاجة
    ```
 

--- a/env.example
+++ b/env.example
@@ -1,5 +1,6 @@
 # Flask Configuration
 FLASK_ENV=development
+FLASK_SECRET_KEY=your-secret-key-here-change-this-in-production
 SECRET_KEY=your-secret-key-here-change-this-in-production
 DEBUG=True
 FLASK_DEBUG=1

--- a/web_interface.py
+++ b/web_interface.py
@@ -6,6 +6,7 @@ from security_module import SecurityManager, SecureDatabase, InputValidator, Rat
 from performance_module import PerformanceManager, record_performance_event
 import json
 import logging
+import os
 from datetime import datetime
 
 # Configure logging
@@ -13,7 +14,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
-app.secret_key = 'deerfields_mall_secret_key_2024'
+app.secret_key = os.getenv("FLASK_SECRET_KEY")
 
 # Initialize CSRF protection
 csrf = CSRFProtect(app)


### PR DESCRIPTION
## Summary
- Load the Flask app's secret key from the `FLASK_SECRET_KEY` environment variable instead of a hard‑coded value.
- Add `FLASK_SECRET_KEY` to configuration examples and docs to highlight that it must be set.

## Testing
- `pytest` *(fails: SyntaxError in `test_ui_system.py`)*

------
https://chatgpt.com/codex/tasks/task_e_689221dad674832eae7d7204439a18d8