### PR TITLE
Use environment variable for Flask secret key

### DIFF
--- a/CONFIGURATION_SETUP_SUMMARY.md
+++ b/CONFIGURATION_SETUP_SUMMARY.md
@@ -112,7 +112,7 @@
 
 ### Environment Variables:
 - **JWT_SECRET_KEY** - JWT token signing
-- **FLASK_SECRET_KEY** - Flask session security
+- **FLASK_SECRET_KEY** - Flask session security (**required**)
 - **DATABASE_URL** - Database connection
 - **REDIS_URL** - Cache connection
 - **MFA_ENABLED** - Multi-factor authentication
@@ -265,7 +265,7 @@ docker-compose --profile staging up -d
 
 ### ✅ Required Setup:
 - [ ] Copy `env.example` to `.env`
-- [ ] Set secure `FLASK_SECRET_KEY` and `JWT_SECRET_KEY`
+- [ ] Set secure `FLASK_SECRET_KEY` (required) and `JWT_SECRET_KEY`
 - [ ] Configure `DATABASE_URL` for your environment
 - [ ] Set `REDIS_URL` if using Redis
 - [ ] Configure `FLASK_ENV` (development/production/testing)

--- a/README.md
+++ b/README.md
@@ -80,9 +80,11 @@
 3. **إعداد متغيرات البيئة**
    ```bash
    cp env.example .env
-   export FLASK_SECRET_KEY=your-secret-key
+   export FLASK_SECRET_KEY=your-secret-key  # Required for session security
    # تحرير ملف .env حسب الحاجة
    ```
+
+   تأكد من تعيين متغير البيئة `FLASK_SECRET_KEY` قبل تشغيل التطبيق، فهو ضروري لحماية الجلسات.
 
 4. **تشغيل النظام**
    ```bash

--- a/env.example
+++ b/env.example
@@ -1,5 +1,6 @@
 # Flask Configuration
 FLASK_ENV=development
+# FLASK_SECRET_KEY is required for session security
 FLASK_SECRET_KEY=your-secret-key-here-change-this-in-production
 SECRET_KEY=your-secret-key-here-change-this-in-production
 DEBUG=True

--- a/web_interface.py
+++ b/web_interface.py
@@ -28,6 +28,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
+# Secret key must be provided via environment variable for session security
 app.secret_key = os.getenv("FLASK_SECRET_KEY")
 
 app.config['BABEL_DEFAULT_LOCALE'] = 'en'


### PR DESCRIPTION
## Summary
- Clarify Flask configuration to source session secret from the `FLASK_SECRET_KEY` environment variable.
- Document requirement for `FLASK_SECRET_KEY` in README and example environment file.
- Highlight `FLASK_SECRET_KEY` as a required setting in configuration summary.

## Testing
- `pytest` *(fails: IndentationError in mall_gamification_system.py)*

------
https://chatgpt.com/codex/tasks/task_e_68931b5850cc832e9a814a4dcadc2492