### PR TITLE
Use hashed passwords for login

### DIFF
--- a/database.py
+++ b/database.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional, Any, Tuple
 import logging
 import uuid
 from pathlib import Path
+from werkzeug.security import generate_password_hash
 
 class MallDatabase:
     """Enhanced database manager for mall gamification system"""
@@ -26,6 +27,7 @@ class MallDatabase:
         self.create_tables()
         self.create_indexes()
         self.run_migrations()
+        self.seed_demo_user()
     
     def setup_logging(self):
         """Setup database logging"""
@@ -42,6 +44,7 @@ class MallDatabase:
                     name TEXT NOT NULL,
                     email TEXT UNIQUE,
                     phone TEXT,
+                    password_hash TEXT,
                     coins INTEGER DEFAULT 0,
                     xp INTEGER DEFAULT 0,
                     level INTEGER DEFAULT 1,
@@ -595,6 +598,11 @@ class MallDatabase:
                         ALTER TABLE missions ADD COLUMN difficulty TEXT DEFAULT 'normal';
                         ALTER TABLE missions ADD COLUMN personalized BOOLEAN DEFAULT FALSE;
                     '''
+                },
+                {
+                    'version': '1.6.0',
+                    'description': 'Add password_hash column to users table',
+                    'sql': "ALTER TABLE users ADD COLUMN password_hash TEXT"
                 }
             ]
             
@@ -625,7 +633,22 @@ class MallDatabase:
         except Exception as e:
             self.logger.error(f"Error running migrations: {e}")
             raise
-    
+
+    def seed_demo_user(self):
+        """Insert a default demo user with a hashed password if it doesn't exist"""
+        try:
+            cursor = self.conn.execute("SELECT 1 FROM users WHERE user_id = ?", ("demo",))
+            if not cursor.fetchone():
+                password_hash = generate_password_hash("demo123")
+                self.conn.execute(
+                    """INSERT INTO users (user_id, name, email, password_hash)
+                       VALUES (?, ?, ?, ?)""",
+                    ("demo", "Demo User", "demo@example.com", password_hash)
+                )
+                self.conn.commit()
+        except Exception as e:
+            self.logger.error(f"Error seeding demo user: {e}")
+
     def backup_database(self, backup_path: str = None) -> bool:
         """Create a backup of the database"""
         try:
@@ -804,8 +827,8 @@ class MallDatabase:
             
             # Whitelist allowed columns for security
             allowed_columns = {
-                'name', 'email', 'phone', 'coins', 'xp', 'level', 'vip_tier', 
-                'vip_points', 'login_streak', 'max_streak', 'total_spent', 
+                'name', 'email', 'phone', 'password_hash', 'coins', 'xp', 'level', 'vip_tier',
+                'vip_points', 'login_streak', 'max_streak', 'total_spent',
                 'total_purchases', 'visited_categories', 'achievement_points',
                 'social_score', 'friends', 'team_id', 'leaderboard_position',
                 'social_achievements', 'event_participation', 'seasonal_progress',

--- a/web_interface.py
+++ b/web_interface.py
@@ -1,23 +1,18 @@
 # Web Interface for Mall Gamification AI Control Panel
 from flask import Flask, render_template, request, jsonify, session, redirect, url_for, abort
 from flask_wtf.csrf import CSRFProtect
-from flask_babel import Babel, gettext as _
-from mall_gamification_system import MallGamificationSystem, User
+from flask_babel import Babel
+from mall_gamification_system import MallGamificationSystem
 from coin_duel import CoinDuelManager
 from security_module import SecurityManager, SecureDatabase, InputValidator, RateLimiter, log_security_event
 from performance_module import PerformanceManager, record_performance_event
- codex/design-voucher-issuance-and-management-system
 from voucher_system import voucher_system
-=======
- codex/implement-real-time-leaderboard-service
 from leaderboard_service import LeaderboardService
+from database import MallDatabase
+from werkzeug.security import check_password_hash
 
- codex/develop-milestone-rewards-system
 from milestone_rewards import MilestoneRewards
 from i18n import translator, get_locale
- main
- main
- main
 import json
 import logging
 import os
@@ -51,10 +46,9 @@ secure_db = SecureDatabase()
 input_validator = InputValidator()
 rate_limiter = RateLimiter()
 performance_manager = PerformanceManager()
- codex/implement-real-time-leaderboard-service
 leaderboard_service = LeaderboardService(mall_system)
+mall_db = MallDatabase()
 
-<codex/add-coin-duel-functionality-to-project
 coin_duel_manager = CoinDuelManager(mall_system)
 
 milestone_rewards = MilestoneRewards()
@@ -75,8 +69,6 @@ def serve_locale(lang):
         data = translator.translations.get(lang, {})
     session['lang'] = lang
     return jsonify(data)
-main
- main
 
 # -----------------------------
 # AUTHENTICATION ROUTES
@@ -105,28 +97,20 @@ def login():
     
     # Validate input
     if not user_id or not password:
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'error': _('user_id_password_required')}), 400
-=======
         return jsonify({'error': translator.gettext('user_password_required', lang)}), 400
- main
-    
-    # Get user
+
+    # Fetch user credentials from database
+    user_record = mall_db.get_user(user_id)
+    if not user_record:
+        return jsonify({'error': translator.gettext('user_not_found', lang)}), 404
+
+    if not user_record.get('password_hash') or not check_password_hash(user_record['password_hash'], password):
+        return jsonify({'error': translator.gettext('invalid_credentials', lang)}), 401
+
+    # Ensure user exists in mall system
     user = mall_system.get_user(user_id)
     if not user:
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'error': _('user_not_found')}), 404
-    
-    # Verify password (simplified for demo - in production use proper password hashing)
-    if password != "demo123":  # Replace with proper password verification
-        return jsonify({'error': _('invalid_credentials')}), 401
-=======
-        return jsonify({'error': translator.gettext('user_not_found', lang)}), 404
-    
-    # Verify password (simplified for demo - in production use proper password hashing)
-    if password != "demo123":  # Replace with proper password verification
-        return jsonify({'error': translator.gettext('invalid_credentials', lang)}), 401
- main
+        user = mall_system.create_user(user_id, lang)
     
     # Check if MFA is enabled for this user
     mfa_settings = secure_db.get_mfa_settings(user_id)
@@ -134,21 +118,13 @@ def login():
     if mfa_settings and mfa_settings['mfa_enabled']:
         # MFA is enabled, verify OTP
         if not otp:
- codex/add-localization-framework-to-web_interface.py
-            return jsonify({'error': _('otp_required'), 'mfa_required': True}), 401
-=======
             return jsonify({'error': translator.gettext('otp_required', lang), 'mfa_required': True}), 401
- main
         
         # Verify OTP
         if not security_manager.verify_otp(mfa_settings['mfa_secret'], otp):
             # Log failed attempt
             secure_db.log_mfa_attempt(user_id, 'otp', False)
- codex/add-localization-framework-to-web_interface.py
-            return jsonify({'error': _('invalid_otp'), 'mfa_required': True}), 403
-=======
             return jsonify({'error': translator.gettext('otp_invalid', lang), 'mfa_required': True}), 403
- main
         
         # Log successful attempt
         secure_db.log_mfa_attempt(user_id, 'otp', True)
@@ -189,71 +165,38 @@ def mfa_setup():
 
     user_id = session['user_id']
     lang = get_locale()
-    
+
     if request.method == 'GET':
-        # Generate new MFA secret
         mfa_secret = security_manager.generate_mfa_secret()
         qr_code_url = security_manager.generate_mfa_qr_code(user_id, mfa_secret)
         backup_codes = security_manager.generate_backup_codes()
-        
-        # Store temporarily in session
         session['mfa_setup'] = {
             'secret': mfa_secret,
             'backup_codes': backup_codes
         }
-        
-        return render_template('mfa_setup.html', 
-                             qr_code_url=qr_code_url, 
-                             backup_codes=backup_codes,
-                             user_id=user_id)
-    
-    # Handle MFA setup confirmation
+        return render_template('mfa_setup.html', qr_code_url=qr_code_url, backup_codes=backup_codes, user_id=user_id)
+
     data = request.get_json() if request.is_json else request.form
     otp = data.get('otp')
-    
+
     if not otp:
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'error': _('otp_required')}), 400
-    
-    mfa_setup_data = session.get('mfa_setup')
-    if not mfa_setup_data:
-        return jsonify({'error': _('mfa_setup_session_expired')}), 400
-    
-    # Verify OTP
-    if not security_manager.verify_otp(mfa_setup_data['secret'], otp):
-        return jsonify({'error': _('invalid_otp')}), 403
-=======
         return jsonify({'error': translator.gettext('otp_required', lang)}), 400
-    
+
     mfa_setup_data = session.get('mfa_setup')
     if not mfa_setup_data:
         return jsonify({'error': translator.gettext('mfa_setup_session_expired', lang)}), 400
-    
-    # Verify OTP
+
     if not security_manager.verify_otp(mfa_setup_data['secret'], otp):
         return jsonify({'error': translator.gettext('otp_invalid', lang)}), 403
- main
-    
-    # Save MFA settings
+
     if secure_db.save_mfa_settings(user_id, mfa_setup_data['secret'], mfa_setup_data['backup_codes']):
-        # Enable MFA
         secure_db.enable_mfa(user_id)
-        
-        # Clear setup session
         session.pop('mfa_setup', None)
-        
-        # Log security event
         secure_db.log_security_event(user_id, 'mfa_enabled', 'MFA setup completed')
-        
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'success': True, 'message': _('mfa_enabled_success')})
-    else:
-        return jsonify({'error': _('failed_to_save_mfa_settings')}), 500
-=======
         return jsonify({'success': True, 'message': translator.gettext('mfa_enabled_success', lang)})
     else:
         return jsonify({'error': translator.gettext('failed_save_mfa', lang)}), 500
- main
+
 
 @app.route('/mfa/verify', methods=['POST'])
 def mfa_verify():
@@ -263,107 +206,59 @@ def mfa_verify():
     user_id = data.get('user_id')
     otp = data.get('otp')
     backup_code = data.get('backup_code')
-    
+
     if not user_id:
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'error': _('user_id_required')}), 400
-=======
         return jsonify({'error': translator.gettext('user_id_required', lang)}), 400
- main
-    
-    # Get MFA settings
+
     mfa_settings = secure_db.get_mfa_settings(user_id)
     if not mfa_settings or not mfa_settings['mfa_enabled']:
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'error': _('mfa_not_enabled')}), 400
-=======
         return jsonify({'error': translator.gettext('mfa_not_enabled', lang)}), 400
- main
-    
+
     success = False
     attempt_type = None
-    
+
     if otp:
-        # Verify OTP
         success = security_manager.verify_otp(mfa_settings['mfa_secret'], otp)
         attempt_type = 'otp'
     elif backup_code:
-        # Verify backup code
         success = security_manager.verify_backup_code(mfa_settings['backup_codes'], backup_code)
         if success:
-            # Update backup codes in database
             secure_db.update_backup_codes(user_id, mfa_settings['backup_codes'])
         attempt_type = 'backup'
     else:
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'error': _('otp_or_backup_required')}), 400
-=======
         return jsonify({'error': translator.gettext('otp_or_backup_required', lang)}), 400
- main
-    
-    # Log attempt
+
     secure_db.log_mfa_attempt(user_id, attempt_type, success)
-    
+
     if success:
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'success': True, 'message': _('mfa_verification_success')})
-    else:
-        return jsonify({'error': _('invalid_otp')}), 403
-=======
         return jsonify({'success': True, 'message': translator.gettext('mfa_verify_success', lang)})
     else:
         return jsonify({'error': translator.gettext('otp_invalid', lang)}), 403
- main
+
 
 @app.route('/mfa/disable', methods=['POST'])
 def mfa_disable():
     """Disable MFA for user"""
     lang = get_locale()
     if 'user_id' not in session:
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'error': _('authentication_required')}), 401
-    
-=======
         return jsonify({'error': translator.gettext('authentication_required', lang)}), 401
 
- main
     user_id = session['user_id']
     data = request.get_json() if request.is_json else request.form
     otp = data.get('otp')
 
-    # Get MFA settings
     mfa_settings = secure_db.get_mfa_settings(user_id)
     if not mfa_settings or not mfa_settings['mfa_enabled']:
-        return jsonify({'error': _('mfa_not_enabled')}), 400
-    
-    # Verify OTP before disabling
-    if not security_manager.verify_otp(mfa_settings['mfa_secret'], otp):
-        return jsonify({'error': _('invalid_otp')}), 403
-    
-    # Disable MFA
-    if secure_db.disable_mfa(user_id):
-        secure_db.log_security_event(user_id, 'mfa_disabled', 'MFA disabled by user')
-        return jsonify({'success': True, 'message': _('mfa_disabled_success')})
-    else:
-        return jsonify({'error': _('failed_to_disable_mfa')}), 500
-=======
         return jsonify({'error': translator.gettext('mfa_not_enabled', lang)}), 400
 
-    # Verify OTP before disabling
     if not security_manager.verify_otp(mfa_settings['mfa_secret'], otp):
         return jsonify({'error': translator.gettext('otp_invalid', lang)}), 403
 
-    # Disable MFA
     if secure_db.disable_mfa(user_id):
         secure_db.log_security_event(user_id, 'mfa_disabled', 'MFA disabled by user')
         return jsonify({'success': True, 'message': translator.gettext('mfa_disabled_success', lang)})
     else:
         return jsonify({'error': translator.gettext('failed_disable_mfa', lang)}), 500
- main
-
-# -----------------------------
-# ROUTES FOR DIFFERENT DASHBOARDS
-# -----------------------------
 
 @app.route('/')
 def index():
@@ -383,7 +278,6 @@ def player_dashboard(user_id):
 
     user.login()
     dashboard_data = mall_system.get_user_dashboard(user_id)
- codex/add-coin-duel-functionality-to-project
     return render_template('player_dashboard.html',
                          user=user,
                          dashboard=dashboard_data,
@@ -396,7 +290,6 @@ def player_dashboard(user_id):
                          user=user,
                          dashboard=dashboard_data,
                          milestones=available_milestones)
- main
 
 @app.route('/admin')
 def admin_dashboard():
@@ -434,7 +327,6 @@ def customer_service_dashboard():
     return render_template('customer_service_dashboard.html', dashboard=dashboard_data)
 
 
- codex/create-webar-treasure-hunt-module
 @app.route('/webar/treasure-hunt', methods=['GET', 'POST'])
 def webar_treasure_hunt():
     """WebAR Treasure Hunt interaction"""
@@ -448,7 +340,6 @@ def webar_treasure_hunt():
     result = mall_system.participate_treasure_hunt(user_id)
     return jsonify(result)
 
-=======
 # -----------------------------
 # VOUCHER ROUTES
 # -----------------------------
@@ -574,7 +465,6 @@ def duel_status(duel_id):
         return jsonify({'error': 'Duel not found'}), 404
     return jsonify(duel)
 
- main
 # -----------------------------
 # API ENDPOINTS
 # -----------------------------
@@ -585,11 +475,7 @@ def api_submit_receipt():
     # Check authentication
     lang = get_locale()
     if 'user_id' not in session:
- codex/add-localization-framework-to-web_interface.py
-        return jsonify({'error': _('authentication_required')}), 401
-=======
         return jsonify({'error': translator.gettext('authentication_required', lang)}), 401
- main
     
     # Rate limiting
     if not secure_db.check_rate_limit(request.remote_addr, 'submit_receipt', 10, 60):


### PR DESCRIPTION
## Summary
- load user credentials via `MallDatabase` and verify passwords using Werkzeug hashes in the web login route
- store password hashes in the users table and seed a demo account for testing
- add migration and update user update whitelist for the new `password_hash` column

## Testing
- `pytest -q test_authentication_manager.py::test_password_hashing test_security_module_updated.py::test_bcrypt_password_hashing`
- `pytest -q test_database_comprehensive.py::test_user_crud_operations`

------
https://chatgpt.com/codex/tasks/task_e_68931b597a88832e8bbb8737a685566f