### PR TITLE
Add discounts service and route

### DIFF
--- a/discounts_service.py
+++ b/discounts_service.py
@@ -1,0 +1,62 @@
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+DEFAULT_PROMOTIONS: List[Dict[str, Any]] = [
+    {
+        "title": "Buy 1 Get 1 Free",
+        "description": "On select items at participating stores.",
+        "valid_until": "2025-12-31",
+    },
+    {
+        "title": "Free Parking Weekend",
+        "description": "Enjoy free parking every weekend this month.",
+        "valid_until": "2025-12-31",
+    },
+]
+
+
+class DiscountsService:
+    """Service to retrieve and cache current mall promotions."""
+
+    def __init__(self, api_url: Optional[str] = None, cache_ttl: int = 300) -> None:
+        """Initialize the service.
+
+        Args:
+            api_url: Optional URL to fetch promotions from.
+            cache_ttl: Time in seconds before cached data expires.
+        """
+        self.api_url = api_url or os.getenv("MALL_PROMOTIONS_URL")
+        self.cache_ttl = cache_ttl
+        self._cache: List[Dict[str, Any]] = []
+        self._expires_at = 0.0
+
+    def _fetch_promotions(self) -> List[Dict[str, Any]]:
+        """Fetch promotions from the API or return defaults."""
+        if not self.api_url:
+            return DEFAULT_PROMOTIONS
+
+        response = requests.get(self.api_url, timeout=5)
+        response.raise_for_status()
+        data = response.json()
+        if isinstance(data, dict) and "promotions" in data:
+            return data["promotions"]  # type: ignore[return-value]
+        return data  # type: ignore[return-value]
+
+    def get_discounts(self) -> List[Dict[str, Any]]:
+        """Return cached promotions, refreshing as needed."""
+        now = time.time()
+        if now >= self._expires_at:
+            try:
+                self._cache = self._fetch_promotions()
+            except Exception:
+                if not self._cache:
+                    self._cache = DEFAULT_PROMOTIONS
+            self._expires_at = now + self.cache_ttl
+        return self._cache
+
+
+# Create a default instance for convenience
+discounts_service = DiscountsService()

--- a/optimized_web_interface.py
+++ b/optimized_web_interface.py
@@ -13,10 +13,11 @@ from security_module import (
     get_secure_database, get_rate_limiter
 )
 from performance_module import (
-    PerformanceManager, AsyncTaskManager, CachedDatabase, 
+    PerformanceManager, AsyncTaskManager, CachedDatabase,
     PerformanceMonitor, OptimizedGraphicsEngine, record_performance_event,
     get_performance_manager, get_performance_monitor, get_optimized_graphics
 )
+from discounts_service import DiscountsService
 import time
 import asyncio
 import logging
@@ -35,6 +36,9 @@ security_manager = get_security_manager()
 secure_database = get_secure_database()
 rate_limiter = get_rate_limiter()
 input_validator = InputValidator()
+
+# Initialize discounts service
+discounts_service = DiscountsService()
 
 # Initialize performance systems
 performance_manager = get_performance_manager()
@@ -56,8 +60,16 @@ def index():
     # Record performance
     response_time = time.time() - start_time
     record_performance_event('main_page', response_time)
-    
+
     return render_template('index.html')
+
+
+@app.route('/discounts')
+@rate_limiter.limit(max_requests=30, window_seconds=60)
+def discounts():
+    """Display current mall promotions."""
+    offers = discounts_service.get_discounts()
+    return render_template('discounts.html', offers=offers)
 
 @app.route('/login', methods=['GET', 'POST'])
 @rate_limiter.limit(max_requests=5, window_seconds=300)

--- a/templates/discounts.html
+++ b/templates/discounts.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Current Promotions</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container py-5">
+    <h1 class="mb-4">Current Promotions</h1>
+    {% if offers %}
+    <div class="row">
+        {% for offer in offers %}
+        <div class="col-md-4 mb-3">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title">{{ offer.title }}</h5>
+                    <p class="card-text">{{ offer.description }}</p>
+                    {% if offer.valid_until %}
+                    <p class="text-muted"><small>Valid until {{ offer.valid_until }}</small></p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% else %}
+    <p>No promotions available at this time.</p>
+    {% endif %}
+</body>
+</html>

--- a/test_web_interface_comprehensive.py
+++ b/test_web_interface_comprehensive.py
@@ -30,6 +30,17 @@ def test_main_routes():
         assert 'status' in health_data
         assert health_data['status'] == 'healthy'
 
+
+def test_discounts_route():
+    """Ensure discounts page is accessible"""
+    print("\n=== Testing Discounts Route ===")
+
+    with app.test_client() as client:
+        response = client.get('/discounts')
+        print(f"Discounts page status: {response.status_code}")
+        assert response.status_code == 200
+        assert b"Current Promotions" in response.data
+
 def test_authentication_routes():
     """Test authentication routes"""
     print("\n=== Testing Authentication Routes ===")


### PR DESCRIPTION
## Summary
- implement `DiscountsService` with cached promotion retrieval
- add `/discounts` route in optimized web interface using new service
- include `discounts.html` template and tests for new page

## Testing
- `pytest test_web_interface_comprehensive.py::test_discounts_route -q` *(fails: IndentationError in mall_gamification_system.py)*

------
https://chatgpt.com/codex/tasks/task_e_68931b601988832eb25d6d143e98925b