### PR TITLE
Add voucher management and audit interfaces

### DIFF
--- a/templates/admin_vouchers.html
+++ b/templates/admin_vouchers.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Voucher Management</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+    <h1 class="mb-4">Voucher Management</h1>
+    <form id="issueForm" class="row g-3 mb-4">
+        <div class="col-md-3">
+            <input type="number" step="0.01" class="form-control" id="value" placeholder="Value" required>
+        </div>
+        <div class="col-md-3">
+            <input type="text" class="form-control" id="user_id" placeholder="User ID">
+        </div>
+        <div class="col-md-3">
+            <input type="number" class="form-control" id="expires" placeholder="Expires in days">
+        </div>
+        <div class="col-md-3">
+            <button type="submit" class="btn btn-primary w-100">Issue</button>
+        </div>
+    </form>
+    <div id="codeResult" class="mb-3"></div>
+    <table class="table table-bordered" id="voucherTable">
+        <thead>
+        <tr><th>Code</th><th>Value</th><th>User</th><th>Status</th><th>Expires</th></tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+<script>
+async function loadVouchers(){
+    const res = await fetch('/admin/vouchers?format=json');
+    const data = await res.json();
+    const tbody = document.querySelector('#voucherTable tbody');
+    tbody.innerHTML = '';
+    data.vouchers.forEach(v => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${v.code}</td><td>${v.value}</td><td>${v.user_id || ''}</td><td>${v.status}</td><td>${v.expires_at || ''}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+document.getElementById('issueForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const payload = {
+        value: parseFloat(document.getElementById('value').value),
+        user_id: document.getElementById('user_id').value || null,
+        expires_in_days: document.getElementById('expires').value || null
+    };
+    const res = await fetch('/admin/vouchers', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    const resultDiv = document.getElementById('codeResult');
+    if (data.code){
+        resultDiv.innerHTML = `<div class="alert alert-success">Voucher issued: ${data.code}</div>`;
+        loadVouchers();
+    } else {
+        resultDiv.innerHTML = `<div class="alert alert-danger">${data.error || 'Error issuing voucher'}</div>`;
+    }
+});
+
+loadVouchers();
+</script>
+</body>
+</html>

--- a/templates/voucher_audit.html
+++ b/templates/voucher_audit.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Voucher Audit Logs</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+    <h1 class="mb-4">Voucher Audit Logs</h1>
+    <table class="table table-bordered" id="auditTable">
+        <thead>
+        <tr><th>Code</th><th>Action</th><th>User</th><th>By</th><th>Details</th><th>Timestamp</th></tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+<script>
+async function loadLogs(){
+    const res = await fetch('/admin/voucher_audit?format=json');
+    const data = await res.json();
+    const tbody = document.querySelector('#auditTable tbody');
+    tbody.innerHTML = '';
+    data.logs.forEach(log => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${log.voucher_code}</td><td>${log.action}</td><td>${log.user_id || ''}</td><td>${log.performed_by || ''}</td><td>${log.details || ''}</td><td>${log.timestamp}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+loadLogs();
+</script>
+</body>
+</html>

--- a/web_interface.py
+++ b/web_interface.py
@@ -688,7 +688,13 @@ def admin_vouchers():
 
     if request.method == 'GET':
         vouchers = voucher_system.list_vouchers()
-        return jsonify({'vouchers': vouchers})
+        # Serve JSON when explicitly requested, otherwise render HTML page
+        if request.args.get('format') == 'json' or (
+            request.accept_mimetypes.accept_json
+            and not request.accept_mimetypes.accept_html
+        ):
+            return jsonify({'vouchers': vouchers})
+        return render_template('admin_vouchers.html')
 
     data = request.get_json() if request.is_json else request.form
     try:
@@ -723,7 +729,12 @@ def admin_voucher_audit():
     if 'user_id' not in session:
         return jsonify({'error': 'Authentication required'}), 401
     logs = voucher_system.get_audit_logs()
-    return jsonify({'logs': logs})
+    if request.args.get('format') == 'json' or (
+        request.accept_mimetypes.accept_json
+        and not request.accept_mimetypes.accept_html
+    ):
+        return jsonify({'logs': logs})
+    return render_template('voucher_audit.html')
 
 # -----------------------------
 # WHEEL OF FORTUNE ADMIN ENDPOINTS


### PR DESCRIPTION
## Summary
- Serve HTML pages for admin voucher management and audit log review, falling back to JSON when requested.
- Introduce `admin_vouchers.html` for issuing and viewing vouchers from the browser.
- Add `voucher_audit.html` to display audit log entries and track voucher activity.

## Testing
- `pytest` *(fails: IndentationError in unrelated module during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689324892e6c832e85989214d4eb86a0