### PR TITLE
feat: cache mission templates with configurable backend

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -180,6 +180,8 @@ JWT_SECRET_KEY=your-secure-jwt-secret-key-here
 DATABASE_URL=sqlite:///prod_mall_gamification.db
 REDIS_ENABLED=True
 REDIS_URL=redis://localhost:6379/0
+MISSION_TEMPLATE_CACHE_BACKEND=redis
+MISSION_TEMPLATE_CACHE_TTL=600
 ```
 
 ### Step 4: Database Setup
@@ -333,6 +335,8 @@ docker-compose --profile staging up -d
 | `DATABASE_URL` | Database connection | sqlite:///mall_gamification.db | Yes |
 | `REDIS_URL` | Redis connection | redis://localhost:6379/0 | No |
 | `REDIS_ENABLED` | Enable Redis caching | True | No |
+| `MISSION_TEMPLATE_CACHE_BACKEND` | Mission template cache backend (`memory` or `redis`) | memory | No |
+| `MISSION_TEMPLATE_CACHE_TTL` | Cache TTL for mission templates (seconds) | 300 | No |
 | `LOG_LEVEL` | Logging level | INFO | No |
 | `DEBUG` | Debug mode | False | No |
 | `MFA_ENABLED` | Enable MFA | True | No |
@@ -360,6 +364,17 @@ REDIS_URL=redis://redis-server:6379/0
 
 # Redis with authentication
 REDIS_URL=redis://:password@redis-server:6379/0
+```
+
+### Mission Template Cache
+```bash
+# In-memory cache (default)
+MISSION_TEMPLATE_CACHE_BACKEND=memory
+MISSION_TEMPLATE_CACHE_TTL=300
+
+# Redis cache
+MISSION_TEMPLATE_CACHE_BACKEND=redis
+MISSION_TEMPLATE_CACHE_TTL=600
 ```
 
 ## 🔐 Security Setup

--- a/config.py
+++ b/config.py
@@ -46,6 +46,10 @@ class BaseConfig:
     REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
     REDIS_PORT = int(os.getenv('REDIS_PORT', '6379'))
     REDIS_DB = int(os.getenv('REDIS_DB', '0'))
+
+    # Mission Template Cache Configuration
+    MISSION_TEMPLATE_CACHE_BACKEND = os.getenv('MISSION_TEMPLATE_CACHE_BACKEND', 'memory')
+    MISSION_TEMPLATE_CACHE_TTL = int(os.getenv('MISSION_TEMPLATE_CACHE_TTL', '300'))
     
     # Security Configuration
     JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY', secrets.token_hex(32))
@@ -184,6 +188,14 @@ class BaseConfig:
             'async_workers': cls.ASYNC_WORKERS,
             'memory_limit_mb': cls.MEMORY_LIMIT_MB,
             'performance_monitoring': cls.PERFORMANCE_MONITORING
+        }
+
+    @classmethod
+    def get_mission_template_cache_config(cls) -> Dict[str, Any]:
+        """Get mission template cache configuration"""
+        return {
+            'backend': cls.MISSION_TEMPLATE_CACHE_BACKEND,
+            'ttl': cls.MISSION_TEMPLATE_CACHE_TTL
         }
     
     @classmethod

--- a/env.example
+++ b/env.example
@@ -17,6 +17,10 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_DB=0
 
+# Mission Template Cache Configuration
+MISSION_TEMPLATE_CACHE_BACKEND=memory  # options: memory, redis
+MISSION_TEMPLATE_CACHE_TTL=300
+
 # Security Configuration
 JWT_SECRET_KEY=your-jwt-secret-key-change-this-in-production
 JWT_ACCESS_TOKEN_EXPIRES=3600


### PR DESCRIPTION
## Summary
- add `TemplateCache` with optional Redis backend and TTL-based invalidation for mission templates
- use cache in `AIMissionGenerator` and support manual refresh
- expose `MISSION_TEMPLATE_CACHE_BACKEND` and `MISSION_TEMPLATE_CACHE_TTL` settings and document usage

## Testing
- `pytest -q` *(fails: SyntaxError in test_3d_gaming_environment.py and others)*

------
https://chatgpt.com/codex/tasks/task_e_68932ec172b8832e9adecfa2e4a3f987