### PR TITLE
Add success metrics utility

### DIFF
--- a/success_metrics.py
+++ b/success_metrics.py
@@ -1,0 +1,29 @@
+"""Utility to provide key success metrics for user engagement, business performance, and mall outcomes."""
+
+class SuccessMetrics:
+    """Container for application success metrics across multiple domains."""
+
+    def key_metrics(self):
+        """Return structured success metrics for users, business, and mall."""
+        return {
+            "user_metrics": {
+                "DAU": "Target: 10K in month 3",
+                "MAU": "Target: 50K in month 6",
+                "retention_d1": "Target: 60%",
+                "retention_d30": "Target: 25%",
+                "session_length": "Target: 15 min",
+            },
+            "business_metrics": {
+                "conversion": "Game → Purchase: 30%",
+                "arpu": "Average Revenue Per User: $5",
+                "ltv": "Lifetime Value: $50",
+                "cac": "Customer Acquisition: <$10",
+                "viral_coefficient": "Target: >1.2",
+            },
+            "mall_metrics": {
+                "foot_traffic_increase": "+20%",
+                "dwell_time": "+30 minutes",
+                "store_visits": "+3 per trip",
+                "purchase_frequency": "+25%",
+            },
+        }

--- a/test_success_metrics.py
+++ b/test_success_metrics.py
@@ -1,0 +1,14 @@
+"""Tests for the SuccessMetrics utility."""
+
+from success_metrics import SuccessMetrics
+
+
+def test_key_metrics_structure():
+    metrics = SuccessMetrics().key_metrics()
+    assert "user_metrics" in metrics
+    assert "business_metrics" in metrics
+    assert "mall_metrics" in metrics
+
+    assert metrics["user_metrics"]["DAU"] == "Target: 10K in month 3"
+    assert metrics["business_metrics"]["arpu"] == "Average Revenue Per User: $5"
+    assert metrics["mall_metrics"]["foot_traffic_increase"] == "+20%"


### PR DESCRIPTION
## Summary
- Add `SuccessMetrics` class to provide key user, business, and mall metrics
- Include unit test ensuring metric structure and sample values

## Testing
- `pytest test_success_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68936ef3e9b0832ead24e047e064ff90