### PR TITLE
Add monetization model and tests

### DIFF
--- a/monetization_model.py
+++ b/monetization_model.py
@@ -1,0 +1,38 @@
+"""Model encapsulating the platform's monetization strategies."""
+
+from typing import Any, Dict
+
+
+class MonetizationModel:
+    """Represents the revenue streams available to the platform."""
+
+    def revenue_streams(self) -> Dict[str, Dict[str, Any]]:
+        """Return the platform's revenue streams.
+
+        Returns:
+            A nested dictionary describing monetization approaches for
+            different partnership types.
+        """
+        return {
+            "b2b_store_partnerships": {
+                "sponsored_quests": "$100-1000 per quest",
+                "foot_traffic": "$0.50 per unique visitor",
+                "purchase_commission": "2-5% of sales",
+                "featured_placement": "$500-5000/month",
+                "data_insights": "$1000-10000/month",
+            },
+            "b2c_user_revenue": {
+                "vip_subscription": {
+                    "price": "$4.99/month",
+                    "benefits": "2X coins, no ads, exclusive",
+                },
+                "coin_purchases": "Direct IAP",
+                "cosmetics": "Avatar items",
+                "battle_passes": "Seasonal content",
+            },
+            "b2b_mall_partnership": {
+                "licensing": "Revenue share 10-20%",
+                "exclusivity": "Premium fees",
+                "white_label": "Custom versions",
+            },
+        }

--- a/test_monetization_model.py
+++ b/test_monetization_model.py
@@ -1,0 +1,19 @@
+from monetization_model import MonetizationModel
+
+
+def test_revenue_streams_structure():
+    model = MonetizationModel()
+    streams = model.revenue_streams()
+
+    assert "b2b_store_partnerships" in streams
+    assert "b2c_user_revenue" in streams
+    assert "b2b_mall_partnership" in streams
+
+    b2b_store = streams["b2b_store_partnerships"]
+    assert b2b_store["sponsored_quests"] == "$100-1000 per quest"
+
+    b2c_user = streams["b2c_user_revenue"]
+    assert b2c_user["vip_subscription"]["price"] == "$4.99/month"
+
+    b2b_mall = streams["b2b_mall_partnership"]
+    assert b2b_mall["licensing"] == "Revenue share 10-20%"


### PR DESCRIPTION
## Summary
- add MonetizationModel detailing revenue streams for partnerships and user revenue
- test MonetizationModel to ensure expected structure and values

## Testing
- `pytest test_monetization_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68936ed15ce4832ea9b09452821a54de