### PR TITLE
Add wager models and migration

### DIFF
--- a/mallquest_wager/wager_models.py
+++ b/mallquest_wager/wager_models.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+
+from sqlalchemy import Column, String, Float, Integer, DateTime, JSON, ForeignKey
+
+from database import Base
+
+
+class WagerMatch(Base):
+    """Represents a wager match with map and safe zone details."""
+
+    __tablename__ = "wager_matches"
+
+    match_id = Column(String, primary_key=True)
+    stake = Column(Float, default=0.0)
+    pot = Column(Float, default=0.0)
+    status = Column(String, default="pending")
+    map_data = Column(JSON)
+    safe_zones = Column(JSON)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class WagerPlayer(Base):
+    """Tracks players participating in wager matches."""
+
+    __tablename__ = "wager_players"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    match_id = Column(String, ForeignKey("wager_matches.match_id"))
+    user_id = Column(String, ForeignKey("users.user_id"))
+    stake = Column(Float, default=0.0)
+    status = Column(String, default="joined")
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class VoucherCatalog(Base):
+    """Catalog of vouchers available in the system."""
+
+    __tablename__ = "voucher_catalog"
+
+    voucher_id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    description = Column(String)
+    value = Column(Float, default=0.0)
+    metadata = Column(JSON)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/migrations/versions/0003_create_wager_tables.py
+++ b/migrations/versions/0003_create_wager_tables.py
@@ -1,0 +1,52 @@
+"""create wager tables
+
+Revision ID: 0003_create_wager_tables
+Revises: 0002_add_role_to_users
+Create Date: 2024-06-24
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003_create_wager_tables'
+down_revision = '0002_add_role_to_users'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'wager_matches',
+        sa.Column('match_id', sa.String(), primary_key=True),
+        sa.Column('stake', sa.Float(), nullable=True),
+        sa.Column('pot', sa.Float(), nullable=True),
+        sa.Column('status', sa.String(), nullable=True),
+        sa.Column('map_data', sa.JSON(), nullable=True),
+        sa.Column('safe_zones', sa.JSON(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+    )
+    op.create_table(
+        'wager_players',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('match_id', sa.String(), sa.ForeignKey('wager_matches.match_id')),
+        sa.Column('user_id', sa.String(), nullable=False),
+        sa.Column('stake', sa.Float(), nullable=True),
+        sa.Column('status', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+    )
+    op.create_table(
+        'voucher_catalog',
+        sa.Column('voucher_id', sa.String(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=True),
+        sa.Column('value', sa.Float(), nullable=True),
+        sa.Column('metadata', sa.JSON(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('voucher_catalog')
+    op.drop_table('wager_players')
+    op.drop_table('wager_matches')


### PR DESCRIPTION
## Summary
- add `WagerMatch`, `WagerPlayer`, and `VoucherCatalog` SQLAlchemy models using the existing `Base`
- create Alembic migration that sets up `wager_matches`, `wager_players`, and `voucher_catalog` tables

## Testing
- `pytest` *(fails: SyntaxError: invalid decimal literal in test_3d_gaming_environment.py, etc.)*
- `alembic upgrade head` *(fails: ModuleNotFoundError: No module named 'database')*

------
https://chatgpt.com/codex/tasks/task_e_68938581c1f4832e90905c6ec4acbdc1