### PR TITLE
Add wager lobby and wheel templates

### DIFF
--- a/templates/wager/lobby.html
+++ b/templates/wager/lobby.html
@@ -1,0 +1,25 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Wager Lobby</h1>
+<ul>
+    {% for match in matches %}
+    <li>
+        <strong>{{ match.name }}</strong> - Stake: {{ match.stake }}
+        <form method="post" action="{{ url_for('join_match', match_id=match.id) }}" class="d-inline">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="number" name="stake" placeholder="Your stake" required>
+            <button type="submit">Join</button>
+        </form>
+    </li>
+    {% else %}
+    <li>No matches available.</li>
+    {% endfor %}
+</ul>
+<hr>
+<h2>Create Match</h2>
+<form method="post" action="{{ url_for('create_match') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <input type="number" name="stake" placeholder="Stake amount" required>
+    <button type="submit">Create</button>
+</form>
+{% endblock %}

--- a/templates/wager/wheel.html
+++ b/templates/wager/wheel.html
@@ -1,0 +1,51 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Reward Wheel</h1>
+<div id="wheel" class="wheel"></div>
+<div id="reward" class="mt-3"></div>
+<form id="spin-form" method="post" action="{{ url_for('spin_wheel') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <button type="submit" id="spin-btn">Spin</button>
+</form>
+
+<style>
+#wheel {
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    border: 5px solid #333;
+    margin: 20px auto;
+}
+.spinning {
+    animation: spin 1s ease-out;
+}
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(1440deg); }
+}
+</style>
+
+<script>
+const form = document.getElementById('spin-form');
+form.addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const wheel = document.getElementById('wheel');
+    wheel.classList.add('spinning');
+    const csrfToken = form.querySelector('[name=csrf_token]').value;
+    try {
+        const res = await fetch(form.action, {
+            method: 'POST',
+            headers: {'X-CSRFToken': csrfToken},
+        });
+        const data = await res.json();
+        setTimeout(() => {
+            wheel.classList.remove('spinning');
+            document.getElementById('reward').textContent = data.reward || data.error;
+        }, 1000);
+    } catch (err) {
+        wheel.classList.remove('spinning');
+        document.getElementById('reward').textContent = 'Error spinning wheel';
+    }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add lobby template for wager matches with CSRF-protected join and creation forms
- add reward wheel template with spin animation and CSRF protection

## Testing
- `pytest` *(fails: SyntaxError in simple_performance_test.py and 15 other errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68938584ace4832e9da14d424679d76c