### PR TITLE
Clarify wager reward distribution

### DIFF
--- a/GAME_LOGIC.md
+++ b/GAME_LOGIC.md
@@ -1,0 +1,9 @@
+# Game Logic
+
+## Wager Match Rewards
+
+- Players join a match by staking coins, creating a shared **pot**.
+- Eliminating an opponent transfers their stake directly to the killer as a **kill reward**; this does not affect the pot.
+- When only one squad has surviving members, the remaining pot is split evenly among those teammates.
+- If players from more than one squad survive when the match ends, it is treated as a tie and the pot is divided equally among all survivors.
+- Assists are not tracked: only the credited killer receives a kill reward, and assists do not influence pot distribution.

--- a/mallquest_wager/wager_system.py
+++ b/mallquest_wager/wager_system.py
@@ -1,3 +1,13 @@
+"""Core game logic for MallQuest wager matches.
+
+Players stake coins to join a match. Eliminating an opponent immediately
+transfers their stake to the killer as a **kill reward**. When the match
+concludes, any remaining **pot** of staked coins is split evenly among all
+surviving members of the winning squad. If players from multiple squads
+survive, the pot is divided equally across all survivors to resolve the tie.
+Assists are not tracked – only the credited killer receives a kill reward.
+"""
+
 from __future__ import annotations
 
 import uuid
@@ -64,7 +74,12 @@ def join_match(user_id: str, match_id: str, squad_id: str) -> bool:
 
 
 def record_kill(winner_id: str, loser_id: str, match_id: str) -> bool:
-    """Record a kill and transfer coins from loser to winner."""
+    """Record a kill and transfer coins from loser to winner.
+
+    The killer receives the loser's staked amount as an immediate reward. The
+    transfer does not affect the match pot. Assists are ignored – only the
+    player credited with the kill is rewarded.
+    """
     match = _MATCHES.get(match_id)
     if not match or not match.active:
         return False
@@ -103,7 +118,13 @@ def record_kill(winner_id: str, loser_id: str, match_id: str) -> bool:
 
 
 def finish_match(match_id: str) -> Dict[str, int]:
-    """Finish a match and distribute the remaining pot among survivors."""
+    """Finish a match and distribute the remaining pot among survivors.
+
+    Each surviving teammate on the winning squad receives an equal share of
+    the pot. If members of multiple squads remain, the match ends in a tie and
+    the pot is split evenly among all surviving players. Eliminated players and
+    assists do not receive any portion of the pot.
+    """
     match = _MATCHES.get(match_id)
     if not match or not match.active:
         return {}


### PR DESCRIPTION
## Summary
- Document reward flow for wager matches in new GAME_LOGIC.md
- Detail how kills, pot sharing, ties, and assists work in wager_system docstrings

## Testing
- `pytest test_wager_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689392db4eb4832ea9e3cc6db3e36367