### PR TITLE
Add Duel Arena game management

### DIFF
--- a/duel_arena.py
+++ b/duel_arena.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+import uuid
+
+
+class DuelArena:
+    """Manage multi-player coin duels where winner takes the pot."""
+
+    def __init__(self, mall_system):
+        self.mall_system = mall_system
+        self.active_duels = {}
+
+    def create_duel(self, player_ids, stake):
+        """Create a duel with 2-4 players staking an equal amount of coins.
+
+        Args:
+            player_ids (list[str]): IDs of participating users.
+            stake (int): Coins each user stakes.
+        Returns:
+            str: Unique duel identifier.
+        """
+        if not 2 <= len(player_ids) <= 4:
+            raise ValueError("DuelArena requires 2-4 players")
+        duel_id = str(uuid.uuid4())
+        self.active_duels[duel_id] = {
+            "players": list(player_ids),
+            "stake": stake,
+            "pot": stake * len(player_ids),
+            "start_time": datetime.utcnow(),
+        }
+        self.mall_system.log_event(
+            "duel_arena_started",
+            {"duel_id": duel_id, "players": list(player_ids), "stake": stake},
+        )
+        return duel_id
+
+    def conclude_duel(self, duel_id, winner_id):
+        """Finish the duel and allocate the coin pot to the winner."""
+        duel = self.active_duels.pop(duel_id, None)
+        if not duel or winner_id not in duel["players"]:
+            return None
+        pot = duel["pot"]
+        if hasattr(self.mall_system, "award_coins"):
+            self.mall_system.award_coins(winner_id, pot)
+        self.mall_system.log_event(
+            "duel_arena_completed",
+            {"duel_id": duel_id, "winner": winner_id, "pot": pot},
+        )
+        return {"duel_id": duel_id, "winner": winner_id, "pot": pot}
+
+    def get_duel(self, duel_id):
+        """Retrieve active duel information."""
+        return self.active_duels.get(duel_id)

--- a/test_duel_arena.py
+++ b/test_duel_arena.py
@@ -1,0 +1,56 @@
+import pytest
+
+from duel_arena import DuelArena
+
+
+class DummyUser:
+    def __init__(self, user_id):
+        self.user_id = user_id
+        self.coins = 0
+
+
+class DummyMallSystem:
+    def __init__(self):
+        self.events = []
+        self.users = {
+            "alice": DummyUser("alice"),
+            "bob": DummyUser("bob"),
+            "charlie": DummyUser("charlie"),
+            "dave": DummyUser("dave"),
+        }
+
+    def log_event(self, event_type, details):
+        self.events.append((event_type, details))
+
+    def award_coins(self, user_id, amount):
+        self.users[user_id].coins += amount
+
+
+@pytest.fixture
+def mall_system():
+    return DummyMallSystem()
+
+
+def test_duel_creation_and_pot(mall_system):
+    arena = DuelArena(mall_system)
+    duel_id = arena.create_duel(["alice", "bob", "charlie"], stake=10)
+    duel = arena.get_duel(duel_id)
+    assert duel["pot"] == 30
+    assert any(e[0] == "duel_arena_started" and e[1]["duel_id"] == duel_id for e in mall_system.events)
+
+
+def test_conclude_awards_pot(mall_system):
+    arena = DuelArena(mall_system)
+    duel_id = arena.create_duel(["alice", "bob"], stake=15)
+    result = arena.conclude_duel(duel_id, "bob")
+    assert result["pot"] == 30
+    assert mall_system.users["bob"].coins == 30
+    assert any(e[0] == "duel_arena_completed" and e[1]["duel_id"] == duel_id for e in mall_system.events)
+
+
+def test_requires_two_to_four_players(mall_system):
+    arena = DuelArena(mall_system)
+    with pytest.raises(ValueError):
+        arena.create_duel(["alice"], stake=5)
+    with pytest.raises(ValueError):
+        arena.create_duel(["a", "b", "c", "d", "e"], stake=5)


### PR DESCRIPTION
## Summary
- add DuelArena manager for multi-player coin stake duels
- cover Duel Arena creation, pot allocation, and winner handling
- test duel creation, pot distribution, and player count limits

## Testing
- `pytest` *(errors: ImportError: cannot import name 'MallDatabase' from '<unknown module name>')*
- `pytest test_duel_arena.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6893d2ce71b0832e8085dff89738fd0f