### PR TITLE
Add Firebase push service and retention scheduler

### DIFF
--- a/app/services/push_service.py
+++ b/app/services/push_service.py
@@ -1,0 +1,61 @@
+import os
+import time
+import logging
+from typing import Optional
+
+import requests
+
+from database import MallDatabase
+
+logger = logging.getLogger(__name__)
+
+FIREBASE_URL = "https://fcm.googleapis.com/fcm/send"
+FIREBASE_SERVER_KEY = os.getenv("FIREBASE_SERVER_KEY", "")
+
+_db = MallDatabase()
+
+
+def _post_message(token: str, message: str) -> bool:
+    headers = {
+        "Authorization": f"key={FIREBASE_SERVER_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "to": token,
+        "notification": {"title": "MallQuest", "body": message},
+    }
+    response = requests.post(FIREBASE_URL, headers=headers, json=payload, timeout=5)
+    data = response.json() if response.content else {}
+    return response.status_code == 200 and data.get("success") == 1
+
+
+def send_push(user_id: str, message: str, retries: int = 3, db_instance: Optional[MallDatabase] = None) -> bool:
+    """Send a push notification via Firebase and log delivery."""
+    db = db_instance or _db
+    token = f"/topics/{user_id}"
+    success = False
+    for attempt in range(1, retries + 1):
+        try:
+            success = _post_message(token, message)
+            if success:
+                break
+            logger.warning("Push attempt %s failed for user %s", attempt, user_id)
+        except Exception:
+            logger.exception("Error sending push to %s on attempt %s", user_id, attempt)
+        time.sleep(1)
+    db.log_notification(user_id, message, delivered=success)
+    if not success:
+        logger.error("All attempts failed for user %s", user_id)
+    return success
+
+
+def send_retention_push(days: int = 30, db_instance: Optional[MallDatabase] = None) -> int:
+    """Scheduled job to send retention messages to dormant users."""
+    db = db_instance or _db
+    users = db.get_dormant_users(days)
+    message = "We miss you at MallQuest! Come back for a special promo."
+    sent = 0
+    for user in users:
+        if send_push(user["user_id"], message, db_instance=db):
+            sent += 1
+    return sent

--- a/test_push_service.py
+++ b/test_push_service.py
@@ -1,0 +1,57 @@
+import datetime
+import os
+import tempfile
+from unittest.mock import patch, MagicMock
+
+from database import MallDatabase, NotificationLog
+from app.services import push_service
+
+
+def _mock_response(success=True):
+    mock = MagicMock()
+    mock.status_code = 200 if success else 500
+    mock.json.return_value = {"success": 1 if success else 0}
+    mock.content = b"{}"
+    return mock
+
+
+def _fresh_db():
+    fd, path = tempfile.mkstemp(prefix="mq_test", suffix=".db")
+    os.close(fd)
+    return MallDatabase(f"sqlite:///{path}")
+
+
+def test_send_push_logs_success():
+    db = _fresh_db()
+    db.add_user({"user_id": "u1", "name": "Test", "email": "t@example.com"})
+    with patch("app.services.push_service.requests.post", return_value=_mock_response()):
+        assert push_service.send_push("u1", "hello", db_instance=db)
+    session = db._session_for_key("u1")
+    logs = session.query(NotificationLog).filter_by(user_id="u1").all()
+    assert len(logs) == 1 and logs[0].delivered is True
+    session.close()
+
+
+def test_send_retention_push_targets_dormant_users():
+    db = _fresh_db()
+    old = datetime.datetime.utcnow() - datetime.timedelta(days=31)
+    db.add_user({"user_id": "u1", "name": "Dormant", "email": "d@example.com", "updated_at": old})
+    db.add_user({"user_id": "u2", "name": "Active", "email": "a@example.com"})
+    with patch("app.services.push_service.requests.post", return_value=_mock_response()):
+        sent = push_service.send_retention_push(db_instance=db, days=30)
+    assert sent == 1
+    session = db._session_for_key("u1")
+    assert session.query(NotificationLog).filter_by(user_id="u1").count() == 1
+    session.close()
+
+
+def test_send_push_retries_on_failure():
+    db = _fresh_db()
+    db.add_user({"user_id": "u1", "name": "Test", "email": "t@example.com"})
+    with patch("app.services.push_service.requests.post", side_effect=Exception) as post:
+        assert push_service.send_push("u1", "hi", retries=2, db_instance=db) is False
+        assert post.call_count == 2
+    session = db._session_for_key("u1")
+    log = session.query(NotificationLog).first()
+    assert log.delivered is False
+    session.close()


### PR DESCRIPTION
## Summary
- add NotificationLog model and helpers for logging and dormant user queries
- implement Firebase push service with retry and retention job
- cover push service and retention workflow with tests

## Testing
- `pytest test_push_service.py -q`
- `pytest test_database_comprehensive.py::test_database_creation -q`


------
https://chatgpt.com/codex/tasks/task_e_6894692a29b4832e85f6fb555802f3e4