### PR TITLE
Add POS purchase API and store purchase history dashboard

### DIFF
--- a/docs/pos_api.md
+++ b/docs/pos_api.md
@@ -1,0 +1,39 @@
+# POS Purchase API
+
+`POST /api/pos/purchase`
+
+Records a purchase sent from a point-of-sale system. The request body must be JSON with the following fields:
+
+- `store_id` (string): Identifier of the store processing the purchase.
+- `user_id` (string): Identifier of the customer.
+- `amount` (number): Total amount of the purchase.
+- `items` (array): List of purchased items.
+- `timestamp` (string): ISO 8601 timestamp when the purchase occurred.
+
+## Request
+
+```json
+{
+  "store_id": "store1",
+  "user_id": "user123",
+  "amount": 120.5,
+  "items": ["shirt", "shoes"],
+  "timestamp": "2024-01-15T14:30:00"
+}
+```
+
+## Successful Response
+
+Status: `201 Created`
+
+```json
+{ "success": true }
+```
+
+## Error Response
+
+Status: `400 Bad Request`
+
+```json
+{ "error": "user_id is required" }
+```

--- a/templates/shopkeeper_dashboard.html
+++ b/templates/shopkeeper_dashboard.html
@@ -161,6 +161,42 @@
                         </div>
                     </div>
 
+                    <!-- Purchase History -->
+                    <div class="dashboard-card">
+                        <h4><i class="fas fa-shopping-cart"></i> Purchase History</h4>
+                        <div class="table-responsive">
+                            <table class="table table-sm">
+                                <thead>
+                                    <tr>
+                                        <th>Customer ID</th>
+                                        <th>Amount (AED)</th>
+                                        <th>Items</th>
+                                        <th>Time</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for customer_id, records in dashboard.purchase_history.items() %}
+                                        {% for record in records %}
+                                        <tr>
+                                            <td>{{ customer_id }}</td>
+                                            <td>{{ "{:,.2f}".format(record.amount) }}</td>
+                                            <td>{{ record.items }}</td>
+                                            <td>{{ record.timestamp.strftime('%Y-%m-%d %H:%M') }}</td>
+                                        </tr>
+                                        {% endfor %}
+                                    {% endfor %}
+                                    {% if dashboard.purchase_history|length == 0 %}
+                                    <tr>
+                                        <td colspan="4">
+                                            <div class="alert alert-info mb-0">No purchases yet</div>
+                                        </td>
+                                    </tr>
+                                    {% endif %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
                     <!-- Special Offers -->
                     <div class="dashboard-card">
                         <h4><i class="fas fa-tags"></i> Special Offers</h4>

--- a/web_interface.py
+++ b/web_interface.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from database import MallDatabase
 from i18n import translator, get_locale
 from mallquest_wager.wager_routes import wager_bp
+from mall_gamification_system import MallGamificationSystem
 
 REQUIRED_ENV = ["SECRET_KEY", "DATABASE_URL", "JWT_SECRET_KEY"]
 for var in REQUIRED_ENV:
@@ -27,6 +28,7 @@ if JWTManager:
 
 mall_db = MallDatabase()
 app.register_blueprint(wager_bp, url_prefix='/wager')
+mall_system = MallGamificationSystem()
 
 # Seed demo user for testing and development
 if not mall_db.get_user('demo'):
@@ -70,6 +72,31 @@ def login():
 
     session['user_id'] = user_id
     return jsonify({'success': True, 'user_id': user_id})
+
+
+@app.route('/api/pos/purchase', methods=['POST'])
+def pos_purchase():
+    """Record POS purchase and forward to purchase logger."""
+    data = request.get_json() or {}
+    required = ['store_id', 'user_id', 'amount', 'items', 'timestamp']
+    for field in required:
+        if field not in data:
+            return jsonify({'error': f'{field} is required'}), 400
+
+    store_id = data['store_id']
+    user_id = data['user_id']
+    items = data['items']
+
+    try:
+        amount = float(data['amount'])
+        timestamp = datetime.fromisoformat(data['timestamp'])
+    except (ValueError, TypeError):
+        return jsonify({'error': 'Invalid amount or timestamp'}), 400
+
+    if not mall_system.add_purchase_record(store_id, user_id, amount, items, timestamp):
+        return jsonify({'error': 'Unable to record purchase'}), 400
+
+    return jsonify({'success': True}), 201
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `/api/pos/purchase` endpoint to record POS sales
- track per-customer purchase history for shopkeepers
- document POS purchase API

## Testing
- `pytest` *(fails: SyntaxError in simple_performance_test.py and others)*

------
https://chatgpt.com/codex/tasks/task_e_6894692bffe8832ea9f0b1a770b7b0b7