### PR TITLE
Implement basic MallQuest game APIs and WebSocket logic

### DIFF
--- a/app/api/v1/battles.py
+++ b/app/api/v1/battles.py
@@ -1,6 +1,9 @@
 """Battle management endpoints."""
 
+from flask import request
 from flask_restx import Namespace, Resource
+
+from ...core import game_state
 
 
 ns = Namespace("battles", description="Battle operations")
@@ -8,8 +11,14 @@ ns = Namespace("battles", description="Battle operations")
 
 @ns.route("/join")
 class JoinBattle(Resource):
-    """Join a battle."""
+    """Join the default battle and return current participants."""
 
     def post(self):
-        return {"status": "not implemented"}, 501
+        data = request.get_json() or {}
+        player_id = data.get("player_id")
+        if not player_id:
+            return {"error": "player_id required"}, 400
+
+        battle = game_state.join_battle(player_id)
+        return {"battle_id": battle.battle_id, "players": battle.players}
 

--- a/app/api/v1/coins.py
+++ b/app/api/v1/coins.py
@@ -1,6 +1,9 @@
 """Coin-related endpoints."""
 
+from flask import request
 from flask_restx import Namespace, Resource
+
+from ...core import game_state
 
 
 ns = Namespace("coins", description="Coin operations")
@@ -8,16 +11,34 @@ ns = Namespace("coins", description="Coin operations")
 
 @ns.route("/nearby")
 class CoinsNearby(Resource):
-    """Return nearby coins."""
+    """Return coins near a given position."""
 
     def get(self):
-        return {"coins": []}
+        try:
+            x = float(request.args.get("x", 0))
+            y = float(request.args.get("y", 0))
+        except ValueError:
+            return {"error": "Invalid coordinates"}, 400
+
+        coins = game_state.get_nearby_coins(x, y)
+        return {"coins": coins}
 
 
 @ns.route("/collect")
 class CollectCoin(Resource):
-    """Collect a coin."""
+    """Collect a coin by ID."""
 
     def post(self):
-        return {"status": "not implemented"}, 501
+        data = request.get_json() or {}
+        player_id = data.get("player_id")
+        coin_id = data.get("coin_id")
+        if not player_id or coin_id is None:
+            return {"error": "player_id and coin_id required"}, 400
+
+        success = game_state.collect_coin(player_id, int(coin_id))
+        if not success:
+            return {"error": "coin not found"}, 404
+
+        player = game_state.players[player_id]
+        return {"status": "collected", "total_coins": player.coins}
 

--- a/app/api/v1/crm.py
+++ b/app/api/v1/crm.py
@@ -2,16 +2,18 @@
 
 from flask_restx import Namespace, Resource
 
+from ...core import game_state
+
 
 ns = Namespace("crm", description="CRM operations")
 
 
 @ns.route("/campaigns")
 class Campaigns(Resource):
-    """Manage marketing campaigns."""
+    """Return configured marketing campaigns."""
 
     def get(self):
-        return {"campaigns": []}
+        return {"campaigns": game_state.campaign_list()}
 
 
 @ns.route("/analytics")
@@ -19,5 +21,5 @@ class Analytics(Resource):
     """Return simple analytics data."""
 
     def get(self):
-        return {"stats": {}}
+        return {"stats": game_state.analytics_summary()}
 

--- a/app/api/v1/quests.py
+++ b/app/api/v1/quests.py
@@ -2,6 +2,8 @@
 
 from flask_restx import Namespace, Resource
 
+from ...core import game_state
+
 
 ns = Namespace("quests", description="Quest operations")
 
@@ -11,5 +13,5 @@ class ListQuests(Resource):
     """List available quests."""
 
     def get(self):
-        return {"quests": []}
+        return {"quests": game_state.list_quests()}
 

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,1 +1,5 @@
 """Core modules for MallQuest application."""
+
+from . import game_state
+
+__all__ = ["game_state"]

--- a/app/core/game_state.py
+++ b/app/core/game_state.py
@@ -1,0 +1,100 @@
+"""In-memory game state and helpers for MallQuest."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+import math
+
+
+@dataclass
+class Player:
+    """Simple player state."""
+
+    player_id: str
+    position: Tuple[float, float] = (0.0, 0.0)
+    coins: int = 0
+
+
+@dataclass
+class Battle:
+    """Basic battle representation."""
+
+    battle_id: str
+    players: List[str] = field(default_factory=list)
+
+
+# Global state containers
+players: Dict[str, Player] = {}
+coins: Dict[int, Tuple[float, float]] = {
+    1: (0.0, 0.0),
+    2: (5.0, 5.0),
+    3: (-3.0, 7.0),
+}
+battles: Dict[str, Battle] = {}
+quests: List[Dict[str, str]] = [
+    {"id": "collect_3", "name": "Collect 3 coins"},
+    {"id": "first_battle", "name": "Join your first battle"},
+]
+
+
+def update_location(player_id: str, x: float, y: float) -> Player:
+    """Update or create a player's location."""
+
+    player = players.setdefault(player_id, Player(player_id))
+    player.position = (x, y)
+    return player
+
+
+def get_nearby_coins(x: float, y: float, radius: float = 10.0) -> List[Dict[str, float]]:
+    """Return coins within ``radius`` of a point."""
+
+    results: List[Dict[str, float]] = []
+    for coin_id, (cx, cy) in coins.items():
+        if math.hypot(cx - x, cy - y) <= radius:
+            results.append({"id": coin_id, "x": cx, "y": cy})
+    return results
+
+
+def collect_coin(player_id: str, coin_id: int) -> bool:
+    """Collect a coin if it exists."""
+
+    if coin_id not in coins:
+        return False
+    players.setdefault(player_id, Player(player_id)).coins += 1
+    del coins[coin_id]
+    return True
+
+
+def join_battle(player_id: str, battle_id: str = "default") -> Battle:
+    """Add ``player_id`` to a battle and return it."""
+
+    battle = battles.setdefault(battle_id, Battle(battle_id))
+    if player_id not in battle.players:
+        battle.players.append(player_id)
+    return battle
+
+
+def list_quests() -> List[Dict[str, str]]:
+    """Return available quests."""
+
+    return quests
+
+
+def campaign_list() -> List[Dict[str, str]]:
+    """Return a static list of CRM campaigns."""
+
+    return [
+        {"id": "summer", "name": "Summer Sale", "active": True},
+        {"id": "loyalty", "name": "Loyalty Bonus", "active": False},
+    ]
+
+
+def analytics_summary() -> Dict[str, int]:
+    """Return simple analytics based on the in-memory state."""
+
+    return {
+        "players": len(players),
+        "coins_collected": sum(p.coins for p in players.values()),
+        "active_battles": len(battles),
+    }

--- a/app/static/js/game_engine.js
+++ b/app/static/js/game_engine.js
@@ -1,0 +1,34 @@
+/* Basic browser game engine logic for MallQuest. */
+
+const socket = io();
+const playerId = Math.random().toString(36).slice(2);
+
+socket.on('connected', (data) => {
+  console.log('connected', data);
+});
+
+socket.on('location_ack', (data) => {
+  console.log('nearby coins', data.nearby_coins);
+});
+
+socket.on('coin_collected', (data) => {
+  console.log('coin collected', data);
+});
+
+socket.on('battle_update', (data) => {
+  console.log('battle update', data);
+});
+
+function sendLocation(x, y) {
+  socket.emit('location_update', { player_id: playerId, x: x, y: y });
+}
+
+function collectCoin(id) {
+  socket.emit('collect_coin', { player_id: playerId, coin_id: id });
+}
+
+function joinBattle() {
+  socket.emit('join_battle', { player_id: playerId });
+}
+
+window.MallQuestGame = { sendLocation, collectCoin, joinBattle };

--- a/app/websocket/events.py
+++ b/app/websocket/events.py
@@ -1,8 +1,10 @@
-"""Socket.IO event handlers for MallQuest."""
+
+"""Socket.IO event handlers implementing basic game logic."""
 
 from flask_socketio import emit
 
 from . import socketio
+from ..core import game_state
 
 
 @socketio.on("connect")
@@ -19,18 +21,36 @@ def handle_disconnect():
 
 @socketio.on("location_update")
 def handle_location_update(data):
-    """Receive a location update from the client."""
-    emit("location_ack", data)
+    """Receive a location update from the client and reply with nearby coins."""
+    player_id = data.get("player_id", "anon")
+    x = float(data.get("x", 0))
+    y = float(data.get("y", 0))
+    game_state.update_location(player_id, x, y)
+    coins = game_state.get_nearby_coins(x, y)
+    emit("location_ack", {"nearby_coins": coins})
 
 
 @socketio.on("join_battle")
 def handle_join_battle(data):
     """Handle a request to join a battle."""
-    emit("battle_joined", data)
+    player_id = data.get("player_id", "anon")
+    battle = game_state.join_battle(player_id)
+    emit(
+        "battle_update",
+        {"battle_id": battle.battle_id, "players": battle.players},
+        broadcast=True,
+    )
 
 
 @socketio.on("collect_coin")
 def handle_collect_coin(data):
     """Handle coin collection events."""
-    emit("coin_collected", data)
+    player_id = data.get("player_id", "anon")
+    coin_id = int(data.get("coin_id", 0))
+    success = game_state.collect_coin(player_id, coin_id)
+    if success:
+        total = game_state.players[player_id].coins
+        emit("coin_collected", {"coin_id": coin_id, "total_coins": total})
+    else:
+        emit("coin_collected", {"error": "coin not found"})
 


### PR DESCRIPTION
## Summary
- add in-memory game state manager for players, coins, battles, quests
- implement coins, battles, quests and CRM API endpoints
- extend WebSocket handlers and frontend script for basic realtime gameplay

## Testing
- `pytest` *(fails: OperationalError: connection to server at "localhost" (127.0.0.1) failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6894b3ade31c832ea7eb2a7519441844