### PR TITLE
Implement basic JWT login endpoint

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -1,15 +1,31 @@
 """Authentication endpoints."""
 
+from flask import request
+from flask_jwt_extended import create_access_token
 from flask_restx import Namespace, Resource
 
 
 ns = Namespace("auth", description="Authentication operations")
 
+# Simple in-memory user store for demonstration purposes
+_USERS = {"admin": "password"}
+
 
 @ns.route("/login")
 class Login(Resource):
-    """Simple login placeholder."""
+    """Authenticate a user and return a JWT access token."""
 
     def post(self):
-        return {"message": "login not implemented"}, 501
+        data = request.get_json() or {}
+        username = data.get("username")
+        password = data.get("password")
+
+        if not username or not password:
+            return {"message": "Missing username or password"}, 400
+
+        if _USERS.get(username) != password:
+            return {"message": "Invalid credentials"}, 401
+
+        access_token = create_access_token(identity=username)
+        return {"access_token": access_token}, 200
 


### PR DESCRIPTION
## Summary
- add basic JWT login endpoint to authenticate users

## Testing
- `pytest -q` *(fails: SyntaxError and database connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894bac9d304832eaf25b3616a1afa5f