### PR TITLE
refactor: load secret key from config

### DIFF
--- a/secure_web_interface.py
+++ b/secure_web_interface.py
@@ -13,11 +13,13 @@ from security_module import (
     get_secure_database, get_rate_limiter
 )
 from database import MallDatabase
+from config import current_config
 import json
 from datetime import datetime
 
 app = Flask(__name__)
-app.secret_key = 'deerfields_mall_secure_secret_key_2024'
+# Load secret key from configuration for improved security
+app.config['SECRET_KEY'] = current_config.SECRET_KEY
 
 # Initialize the mall system and security components
 mall_system = MallGamificationSystem()


### PR DESCRIPTION
## Summary
- load Flask secret key from the existing configuration instead of hardcoding

## Testing
- `pytest` *(fails: psycopg2 OperationalError: connection to server at "localhost" failed)*

------
https://chatgpt.com/codex/tasks/task_e_6894becbe1e0832e9a595b04929c3291