### PR TITLE
Add basic RBAC permission system

### DIFF
--- a/test_authentication_manager.py
+++ b/test_authentication_manager.py
@@ -382,6 +382,22 @@ def test_super_admin_role():
         return False
 
 
+def test_rbac_permissions():
+    """Test role-based permission checks"""
+    print("\n🧪 Testing RBAC Permissions")
+    print("=" * 40)
+
+    try:
+        token = auth_manager.generate_token("admin_user", UserRole.ADMIN.value)
+        assert auth_manager.has_permission(token, "manage_users")
+        assert not auth_manager.has_permission(token, "admin_panel")
+        print("✅ RBAC permission checks successful")
+        return True
+    except Exception as e:
+        print(f"❌ RBAC permission test failed: {e}")
+        return False
+
+
 def test_error_handling():
     """Test error handling and edge cases"""
     print("\n🧪 Testing Error Handling")


### PR DESCRIPTION
## Summary
- add default role-permission mapping to authentication manager
- support checking permissions and decorator for protected routes
- cover role permission logic with new tests

## Testing
- `pytest -q test_authentication_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68951208365c832e829dce4556a3bce0